### PR TITLE
Use ssl:connection_information() instead of ssl:connection_info()

### DIFF
--- a/src/rabbit_net.erl
+++ b/src/rabbit_net.erl
@@ -88,7 +88,10 @@
 is_ssl(Sock) -> ?IS_SSL(Sock).
 
 ssl_info(Sock) when ?IS_SSL(Sock) ->
-    ssl:connection_info(Sock#ssl_socket.ssl);
+    Info = ssl:connection_information(Sock#ssl_socket.ssl),
+    Protocol = proplists:get_value(protocol, Info),
+    {KeyExchange, Cipher, Hash, _} = proplists:get_value(cipher_suite, Info),
+    {Protocol, {KeyExchange, Cipher, Hash}};
 ssl_info(_Sock) ->
     nossl.
 


### PR DESCRIPTION
ssl:connection_info() is removed in OTP-20.